### PR TITLE
feat: theme `getColors` and `colors` for import

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,49 @@ This is also my first lua based anything, your mileage may vary!
 
 VimPlug `Plug 'Deep-Six/pywal-lush',{'branch': 'main'}`
 
+## Configuration
+
+Currently, you may use `lush` to modify the colorscheme directly if you wish.
+The colors are offered by the theme, so you can also use them directly:
+
+```lua
+-- you could save this snippet as a `colors.lua` and require() it, or simply
+-- include it in an existing file.
+
+local lush = require("lush")
+local colors = require("lush_theme.colors")
+local theme = require("lush_theme.pywal")
+
+-- lush allows you to modify a theme built using lush before it gets applied.
+-- `injected_functions` / `local sym` are only for modifying tree-sitter highlights;
+-- feel free to remove them if you're not changing any of those.
+local spec = lush.extends({ theme }).with(function (injected_functions)
+  local sym = injected_functions.sym
+
+  return {
+    -- override the fg for the MatchParen highlight group using a hard-coded value.
+    MatchParen { fg = "white" },
+
+    -- modify NormalFloat's bg, by using the theme's NormalFloat original bg color.
+    NormalFloat { bg = theme.NormalFloat.bg.darken(80) },
+
+    -- use Comment colors, but don't italicize them (the default).
+    Comment { gui = "NONE" },
+
+    -- use theme.Comment.fg for a string, but adjusted (absolute, not relative) lighter.
+    String { fg = theme.Comment.fg.abs_lighten(20) },
+
+    -- use pywal-generated colors directly, but darkened/lightened as you wish.
+    Search { bg = colors.color8.darken(70), fg = colors.color1.lighten(90) },
+
+    -- change a tree-sitter highlight:
+    sym"@string.documentation" { fg = theme.Comment.fg.lighten(20) },
+  }
+end)
+
+lush(spec)
+```
+
 ## Todo
 
 I am trying to get lightline working, but with an eye to move to lualine

--- a/lua/lush_theme/colors.lua
+++ b/lua/lush_theme/colors.lua
@@ -1,0 +1,36 @@
+local hsl = require('lush').hsl
+
+local M = {}
+
+M.getColors = function ()
+  local colorTable = {}
+  local home = os.getenv("HOME")
+  local pywal_colors  = home .. "/.cache/wal/colors"
+  local file = io.open(pywal_colors, "r")
+  for line in file:lines() do
+    table.insert(colorTable, line)
+  end
+  return colorTable
+end
+
+local colors = M.getColors()
+
+-- offer the colors so users can easily modify the theme.
+M.color1 = hsl(colors[1])
+M.color2 = hsl(colors[2])
+M.color3 = hsl(colors[3])
+M.color4 = hsl(colors[4])
+M.color5 = hsl(colors[5])
+M.color6 = hsl(colors[6])
+M.color7 = hsl(colors[7])
+M.color8 = hsl(colors[8])
+M.color9 = hsl(colors[9])
+M.color10 = hsl(colors[10])
+M.color11 = hsl(colors[11])
+M.color12 = hsl(colors[12])
+M.color13 = hsl(colors[13])
+M.color14 = hsl(colors[14])
+M.color15 = hsl(colors[15])
+M.color16 = hsl(colors[16])
+
+return M

--- a/lua/lush_theme/pywal.lua
+++ b/lua/lush_theme/pywal.lua
@@ -45,18 +45,7 @@
 local lush = require('lush')
 local hsl = lush.hsl
 
-function getColors()
-  local colorTable = {}
-  local home = os.getenv("HOME")
-  local pywal_colors  = home .. "/.cache/wal/colors"
-  file = io.open(pywal_colors, "r")
-  for line in file:lines() do
-    table.insert(colorTable,line) 
-  end
-  return colorTable
-end
-
-local colors = getColors()
+local colors = require("lush_theme.colors").getColors()
 
 local theme = lush(function()
   local color1 = hsl(colors[1])

--- a/lua/lush_theme/pywal.lua
+++ b/lua/lush_theme/pywal.lua
@@ -43,27 +43,26 @@
 --  `:lua require('lush').ify()`
 
 local lush = require('lush')
-local hsl = lush.hsl
 
-local colors = require("lush_theme.colors").getColors()
+local colors = require("lush_theme.colors")
 
 local theme = lush(function()
-  local color1 = hsl(colors[1])
-  local color2 = hsl(colors[2])
-  local color3 = hsl(colors[3])
-  local color4 = hsl(colors[4])
-  local color5 = hsl(colors[5])
-  local color6 = hsl(colors[6])
-  local color7 = hsl(colors[7])
-  local color8 = hsl(colors[8])
-  local color9 = hsl(colors[9])
-  local color10 = hsl(colors[10])
-  local color11 = hsl(colors[11])
-  local color12 = hsl(colors[12])
-  local color13 = hsl(colors[13])
-  local color14 = hsl(colors[14])
-  local color15 = hsl(colors[15])
-  local color16 = hsl(colors[16])
+  local color1 = colors.color1
+  local color2 = colors.color2
+  local color3 = colors.color3
+  local color4 = colors.color4
+  local color5 = colors.color5
+  local color6 = colors.color6
+  local color7 = colors.color7
+  local color8 = colors.color8
+  local color9 = colors.color9
+  local color10 = colors.color10
+  local color11 = colors.color11
+  local color12 = colors.color12
+  local color13 = colors.color13
+  local color14 = colors.color14
+  local color15 = colors.color15
+  local color16 = colors.color16
 
   return {
     -- The following are all the Neovim default highlight groups from the docs


### PR DESCRIPTION
Moves `getColors` to a `colors.lua` file so that users can import and use them as necessary in their own theme modifications. Also updated README with samples of theme modification via `lush`.

----

Not sure if you're interested in updating this theme, but I have a couple changes i've made locally that I could submit PRs for if you're interested. This is the first: it extracts the color loading to a separate file so that users can use them directly if desired.